### PR TITLE
Added custom marshallers to manage strings from SDL

### DIFF
--- a/rules/sonar.editorconfig
+++ b/rules/sonar.editorconfig
@@ -1,5 +1,10 @@
 is_global = true
 
+# S101: Types should be named in PascalCase
+# Some types are named in all upper case like SDL
+# https://rules.sonarsource.com/csharp/RSPEC-101/
+dotnet_diagnostic.S101.severity = none
+
 # S1481: Unused local variables should be removed
 # Is a duplicate of IDE0059: https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0059
 # https://rules.sonarsource.com/csharp/RSPEC-1481/

--- a/src/KappaDuck.Aquila/Marshallers/CallerOwnedStringMarshaller.cs
+++ b/src/KappaDuck.Aquila/Marshallers/CallerOwnedStringMarshaller.cs
@@ -1,0 +1,21 @@
+// Copyright (c) KappaDuck. All rights reserved.
+// The source code is licensed under MIT License.
+
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
+
+namespace KappaDuck.Aquila.Marshallers;
+
+[CustomMarshaller(typeof(string), MarshalMode.ManagedToUnmanagedOut, typeof(CallerOwnedStringMarshaller))]
+internal static partial class CallerOwnedStringMarshaller
+{
+    internal static string ConvertToManaged(IntPtr unmanaged)
+        => Marshal.PtrToStringUTF8(unmanaged) ?? string.Empty;
+
+    internal static void Free(IntPtr unmanaged) => SDL_free(unmanaged);
+
+    [LibraryImport(SDL.NativeLibrary)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    private static partial void SDL_free(IntPtr mem);
+}

--- a/src/KappaDuck.Aquila/Marshallers/OwnedStringMarshaller.cs
+++ b/src/KappaDuck.Aquila/Marshallers/OwnedStringMarshaller.cs
@@ -1,0 +1,14 @@
+// Copyright (c) KappaDuck. All rights reserved.
+// The source code is licensed under MIT License.
+
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
+
+namespace KappaDuck.Aquila.Marshallers;
+
+[CustomMarshaller(typeof(string), MarshalMode.ManagedToUnmanagedOut, typeof(OwnedStringMarshaller))]
+internal static class OwnedStringMarshaller
+{
+    internal static string ConvertToManaged(IntPtr unmanaged)
+        => Marshal.PtrToStringUTF8(unmanaged) ?? string.Empty;
+}

--- a/src/KappaDuck.Aquila/SDL.cs
+++ b/src/KappaDuck.Aquila/SDL.cs
@@ -1,0 +1,12 @@
+// Copyright (c) KappaDuck. All rights reserved.
+// The source code is licensed under MIT License.
+
+namespace KappaDuck.Aquila;
+
+/// <summary>
+/// Represents global SDL functions.
+/// </summary>
+public static class SDL
+{
+    internal const string NativeLibrary = "SDL3.dll";
+}


### PR DESCRIPTION
Added two internal custom marshallers which manage string as UTF8 from SDL.

- OwnedStringMarshaller are owned by SDL and take the responsibility to free the string
- CallerOwnedStringMarshaller are owned by the caller and should free the string. (Managed by itself)

Closes #103 