### PR TITLE
Added initialization and shutdown for SDL subsystems

### DIFF
--- a/src/Aquila.Demo/Program.cs
+++ b/src/Aquila.Demo/Program.cs
@@ -1,4 +1,11 @@
 // Copyright (c) KappaDuck. All rights reserved.
 // The source code is licensed under MIT License.
 
+using KappaDuck.Aquila;
+using KappaDuck.Aquila.System;
+
+SDL.Init(SubSystem.Video);
+
 Console.WriteLine("Hello, Aquila!");
+
+SDL.Quit();

--- a/src/KappaDuck.Aquila/SDL.cs
+++ b/src/KappaDuck.Aquila/SDL.cs
@@ -1,12 +1,97 @@
 // Copyright (c) KappaDuck. All rights reserved.
 // The source code is licensed under MIT License.
 
+using KappaDuck.Aquila.System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
 namespace KappaDuck.Aquila;
 
 /// <summary>
 /// Represents global SDL functions.
 /// </summary>
-public static class SDL
+public static partial class SDL
 {
     internal const string NativeLibrary = "SDL3.dll";
+
+    private static SubSystem _initializedSubSystems;
+
+    /// <summary>
+    /// Initializes the specified subsystems.
+    /// </summary>
+    /// <remarks>
+    /// Initialized subsystems are stored and will be uninitialized on <see cref="Quit" /> by using <see cref="QuitSubSystem(SubSystem)"/>
+    /// or call directly <see cref="QuitSubSystem(SubSystem)"/> to shut down specific subsystems.
+    /// You can initialize the same subsystem multiple times. It will only initializes once.
+    /// </remarks>
+    /// <param name="subSystem">The subsystems to initialize.</param>
+    /// <returns>Returns true on success or false on failure.</returns>
+    public static bool Init(SubSystem subSystem)
+    {
+        if ((_initializedSubSystems & subSystem) != SubSystem.None)
+        {
+            return true;
+        }
+
+        if (SDL_InitSubSystem(subSystem))
+        {
+            _initializedSubSystems |= subSystem;
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Clean up all initialized subsystems.
+    /// </summary>
+    /// <remarks>
+    /// It will call <see cref="QuitSubSystem(SubSystem)"/> for initialized subsystems.
+    /// It is safe to call this function even in the case of errors in initialization.
+    /// </remarks>
+    public static void Quit()
+    {
+        QuitSubSystem(_initializedSubSystems);
+        SDL_Quit();
+    }
+
+    /// <summary>
+    /// Shut down specific subsystems.
+    /// </summary>
+    /// <remarks>
+    /// You still need to call <see cref="Quit" /> even if you close all subsystems.
+    /// You can shut down the same subsystem multiple times. It will only shut down once.
+    /// </remarks>
+    /// <param name="subSystem">Any of the subsystem used by <see cref="Init(SubSystem)"/>.</param>
+    public static void QuitSubSystem(SubSystem subSystem)
+    {
+        if ((_initializedSubSystems & subSystem) == SubSystem.None)
+            return;
+
+        SDL_QuitSubSystem(subSystem);
+        _initializedSubSystems &= ~subSystem;
+    }
+
+    /// <summary>
+    /// Get a mask of the specified subsystems which are currently initialized.
+    /// </summary>
+    /// <param name="subSystem">The subsystem to check if it was initialized or <see langword="null"/> to check all subsystems.</param>
+    /// <returns>A mask of all initialized subsystems if <see cref="SubSystem"/> is <see langword="null"/>,
+    /// otherwise it returns the initialization status of the specified subsystem.
+    /// </returns>
+    public static SubSystem WasInit(SubSystem? subSystem)
+        => subSystem.HasValue ? (_initializedSubSystems & subSystem.Value) : _initializedSubSystems;
+
+    [LibraryImport(NativeLibrary)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool SDL_InitSubSystem(SubSystem subSystem);
+
+    [LibraryImport(NativeLibrary)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    private static partial void SDL_QuitSubSystem(SubSystem subSystem);
+
+    [LibraryImport(NativeLibrary)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    private static partial void SDL_Quit();
 }

--- a/src/KappaDuck.Aquila/System/SubSystem.cs
+++ b/src/KappaDuck.Aquila/System/SubSystem.cs
@@ -1,0 +1,66 @@
+// Copyright (c) KappaDuck. All rights reserved.
+// The source code is licensed under MIT License.
+
+namespace KappaDuck.Aquila.System;
+
+/// <summary>
+/// Subsystems to initialize using <see cref="SDL.Init(SubSystem)" />.
+/// </summary>
+[Flags]
+public enum SubSystem : uint
+{
+    /// <summary>
+    /// No subsystem.
+    /// </summary>
+    /// <remarks>
+    /// It is only used to check if the subsystem is already initialized.
+    /// </remarks>
+    None = 0x00000000u,
+
+    /// <summary>
+    /// Initialize the audio subsystem. Implicitly initializes the <see cref="Events" /> subsystem.
+    /// </summary>
+    Audio = 0x00000010u,
+
+    /// <summary>
+    /// Initialize the video subsystem. Implicitly initializes the <see cref="Events" /> subsystem.
+    /// </summary>
+    /// <remarks>
+    /// It should be initialized on the main thread.
+    /// </remarks>
+    Video = 0x00000020u,
+
+    /// <summary>
+    /// Initialize the joystick subsystem. Implicitly initializes the <see cref="Events" /> subsystem.
+    /// </summary>
+    /// <remarks>
+    /// It should be initialized on the same thread as <see cref="Video" /> subsystem
+    /// on Window if you don't set SDL_HINT_JOYSTICK_THREAD.
+    /// </remarks>
+    Joystick = 0x00000200u,
+
+    /// <summary>
+    /// Initialize the Force Feedback subsystem.
+    /// </summary>
+    Haptic = 0x00001000u,
+
+    /// <summary>
+    /// Initialize the gamepad subsystem. Implicitly initializes the <see cref="Joystick" /> subsystem.
+    /// </summary>
+    Gamepad = 0x00002000u,
+
+    /// <summary>
+    /// Initialize the events subsystem.
+    /// </summary>
+    Events = 0x00004000u,
+
+    /// <summary>
+    /// Initialize the sensor subsystem. Implicitly initializes the <see cref="Events" /> subsystem.
+    /// </summary>
+    Sensor = 0x00008000u,
+
+    /// <summary>
+    /// Initialize the camera subsystem. Implicitly initializes the <see cref="Events" /> subsystem.
+    /// </summary>
+    Camera = 0x00010000u,
+}


### PR DESCRIPTION
Added new methods to initialize and shut down SDL subsystems.

Added new enum for subsystems and can be managed as flags

The class SDL will contains theses methods
- Init
- Quit
- QuitSubsystem
- WasInit

Closes #79 